### PR TITLE
Make QueryExpression Deserializable (and serializable). Otherwise it prevents sharepointdocumentlocation Create message

### DIFF
--- a/PowerPlatform.EntitySerializer.Sources/PowerPlatform.EntitySerializer.Sources.nuspec
+++ b/PowerPlatform.EntitySerializer.Sources/PowerPlatform.EntitySerializer.Sources.nuspec
@@ -15,7 +15,7 @@
 		<description>Source Nuget package for serializing an Entity using System.Text.JSON.</description>
 		<releaseNotes>
 			v$version$:
-			- Added Known Guid Attributes option 
+			- Make QueryExpression Deserializable/Serializable (thnx. Jānis Veinbergs)
 		</releaseNotes>
 		<copyright>Copyright 2024</copyright>
 		<tags>Xrm AlbanianXrm Dataverse JSON</tags>

--- a/PowerPlatform.EntitySerializer.Tests/DeserializationEncodingTests.cs
+++ b/PowerPlatform.EntitySerializer.Tests/DeserializationEncodingTests.cs
@@ -714,7 +714,10 @@ namespace AlbanianXrm.PowerPlatform
 
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(input)))
             {
-                var remoteExecutionContext = await EntitySerializer.DeserializeAsync<RemoteExecutionContext>(stream);
+                var remoteExecutionContext = await EntitySerializer.DeserializeAsync<RemoteExecutionContext>(stream, new EntitySerializerOptions()
+                {
+                    EncodingToCorrect = Encoding.GetEncoding(1252)
+                });
 
                 Assert.NotNull(remoteExecutionContext);
                 Assert.NotNull(remoteExecutionContext.InputParameters);

--- a/PowerPlatform.EntitySerializer.Tests/DeserializationFromAllFieldTypes.cs
+++ b/PowerPlatform.EntitySerializer.Tests/DeserializationFromAllFieldTypes.cs
@@ -496,5 +496,482 @@ namespace EntitySerializerTests
             Assert.NotNull(shko_choices);
             Assert.Contains(new OptionSetValue(342490002), shko_choices);
         }
+
+        [Fact]
+        public void DeserializeRemoteExecutionContextWithDocumentLocation()
+        {
+            var serializedContext = @"
+{
+    ""BusinessUnitId"": ""24e33957-e1a1-424e-943d-e8ce84c45633"",
+    ""CorrelationId"": ""01b84871-96b1-48e0-ada2-a31031966e3f"",
+    ""Depth"": 1,
+    ""InitiatingUserAzureActiveDirectoryObjectId"": ""00000000-0000-0000-0000-000000000000"",
+    ""InitiatingUserId"": ""30c91177-9436-4042-ad53-dd966d490114"",
+    ""InputParameters"": [
+        {
+            ""key"": ""Target"",
+            ""value"": {
+                ""__type"": ""Entity:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                ""Attributes"": [
+                    {
+                        ""key"": ""owningbusinessunit"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""24e33957-e1a1-424e-943d-e8ce84c45633"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""businessunit"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""modifiedonbehalfby"",
+                        ""value"": null
+                    },
+                    {
+                        ""key"": ""statecode"",
+                        ""value"": {
+                            ""__type"": ""OptionSetValue:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Value"": 0
+                        }
+                    },
+                    {
+                        ""key"": ""locationtype"",
+                        ""value"": {
+                            ""__type"": ""OptionSetValue:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Value"": 0
+                        }
+                    },
+                    {
+                        ""key"": ""relativeurl"",
+                        ""value"": ""Mini test""
+                    },
+                    {
+                        ""key"": ""createdby"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""30c91177-9436-4042-ad53-dd966d490114"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""systemuser"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""regardingobjectid"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""0a3839b3-08d4-ef11-aeb0-00155d000101"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""account"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""statuscode"",
+                        ""value"": {
+                            ""__type"": ""OptionSetValue:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Value"": 1
+                        }
+                    },
+                    {
+                        ""key"": ""ownerid"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""30c91177-9436-4042-ad53-dd966d490114"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""systemuser"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""sharepointdocumentlocationid"",
+                        ""value"": ""1e3839b3-08d4-ef11-aeb0-00155d000101""
+                    },
+                    {
+                        ""key"": ""modifiedon"",
+                        ""value"": ""\/Date(1737031936000)\/""
+                    },
+                    {
+                        ""key"": ""owninguser"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""30c91177-9436-4042-ad53-dd966d490114"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""systemuser"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""modifiedby"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""30c91177-9436-4042-ad53-dd966d490114"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""systemuser"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""sitecollectionid"",
+                        ""value"": ""b40f92c3-c1cc-ef11-aeae-00155d000101""
+                    },
+                    {
+                        ""key"": ""createdon"",
+                        ""value"": ""\/Date(1737031936000)\/""
+                    },
+                    {
+                        ""key"": ""name"",
+                        ""value"": ""Documents on Default Site 1""
+                    },
+                    {
+                        ""key"": ""parentsiteorlocation"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""90fe6740-1cc1-e211-be17-000c29fb9e40"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""sharepointdocumentlocation"",
+                            ""Name"": null,
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""servicetype"",
+                        ""value"": {
+                            ""__type"": ""OptionSetValue:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Value"": 0
+                        }
+                    }
+                ],
+                ""EntityState"": null,
+                ""FormattedValues"": [
+                    {
+                        ""key"": ""statecode"",
+                        ""value"": ""Active""
+                    },
+                    {
+                        ""key"": ""locationtype"",
+                        ""value"": ""General""
+                    },
+                    {
+                        ""key"": ""statuscode"",
+                        ""value"": ""Active""
+                    },
+                    {
+                        ""key"": ""modifiedon"",
+                        ""value"": ""2025-01-16T14:52:16+02:00""
+                    },
+                    {
+                        ""key"": ""createdon"",
+                        ""value"": ""2025-01-16T14:52:16+02:00""
+                    }
+                ],
+                ""Id"": ""1e3839b3-08d4-ef11-aeb0-00155d000101"",
+                ""KeyAttributes"": [],
+                ""LogicalName"": ""sharepointdocumentlocation"",
+                ""RelatedEntities"": [],
+                ""RowVersion"": null
+            }
+        }
+    ],
+    ""IsExecutingOffline"": false,
+    ""IsInTransaction"": false,
+    ""IsOfflinePlayback"": false,
+    ""IsolationMode"": 1,
+    ""MessageName"": ""Create"",
+    ""Mode"": 1,
+    ""OperationCreatedOn"": ""\/Date(1737024736000+0200)\/"",
+    ""OperationId"": ""203839b3-08d4-ef11-aeb0-00155d000101"",
+    ""OrganizationId"": ""f0aabb07-b0c9-4cfe-80be-8effd49bf067"",
+    ""OrganizationName"": ""ORG"",
+    ""OutputParameters"": [
+        {
+            ""key"": ""id"",
+            ""value"": ""1e3839b3-08d4-ef11-aeb0-00155d000101""
+        }
+    ],
+    ""OwningExtension"": {
+        ""Id"": ""ffd3ea1c-46ae-ef11-8a69-002248e53d94"",
+        ""KeyAttributes"": [],
+        ""LogicalName"": ""sdkmessageprocessingstep"",
+        ""Name"": null,
+        ""RowVersion"": null
+    },
+    ""ParentContext"": {
+        ""BusinessUnitId"": ""24e33957-e1a1-424e-943d-e8ce84c45633"",
+        ""CorrelationId"": ""01b84871-96b1-48e0-ada2-a31031966e3f"",
+        ""Depth"": 1,
+        ""InitiatingUserAzureActiveDirectoryObjectId"": ""00000000-0000-0000-0000-000000000000"",
+        ""InitiatingUserId"": ""30c91177-9436-4042-ad53-dd966d490114"",
+        ""InputParameters"": [
+            {
+                ""key"": ""Query"",
+                ""value"": {
+                    ""__type"": ""QueryExpression:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                    ""ColumnSet"": {
+                        ""AllColumns"": false,
+                        ""AttributeExpressions"": [],
+                        ""Columns"": [
+                            ""documentid"",
+                            ""fullname"",
+                            ""relativelocation"",
+                            ""sharepointcreatedon"",
+                            ""ischeckedout"",
+                            ""filetype"",
+                            ""modified"",
+                            ""sharepointmodifiedby"",
+                            ""servicetype"",
+                            ""absoluteurl"",
+                            ""title"",
+                            ""author"",
+                            ""sharepointdocumentid"",
+                            ""readurl"",
+                            ""editurl"",
+                            ""locationid"",
+                            ""iconclassname"",
+                            ""locationname""
+                        ]
+                    },
+                    ""Criteria"": {
+                        ""Conditions"": [
+                            {
+                                ""AttributeName"": ""isrecursivefetch"",
+                                ""CompareColumns"": false,
+                                ""Operator"": 0,
+                                ""Values"": [
+                                    false
+                                ],
+                                ""EntityName"": null
+                            },
+                            {
+                                ""AttributeName"": ""regardingobjecttypecode"",
+                                ""CompareColumns"": false,
+                                ""Operator"": 0,
+                                ""Values"": [
+                                    1
+                                ],
+                                ""EntityName"": null
+                            },
+                            {
+                                ""AttributeName"": ""regardingobjectid"",
+                                ""CompareColumns"": false,
+                                ""Operator"": 0,
+                                ""Values"": [
+                                    ""0a3839b3-08d4-ef11-aeb0-00155d000101""
+                                ],
+                                ""EntityName"": null
+                            }
+                        ],
+                        ""FilterOperator"": 0,
+                        ""Filters"": []
+                    },
+                    ""Distinct"": false,
+                    ""EntityName"": ""sharepointdocument"",
+                    ""LinkEntities"": [],
+                    ""Orders"": [
+                        {
+                            ""Alias"": null,
+                            ""AttributeName"": ""relativelocation"",
+                            ""OrderType"": 0
+                        }
+                    ],
+                    ""PageInfo"": {
+                        ""Count"": 10,
+                        ""PageNumber"": 1,
+                        ""PagingCookie"": null,
+                        ""ReturnTotalRecordCount"": true
+                    },
+                    ""NoLock"": false,
+                    ""QueryHints"": """"
+                }
+            },
+            {
+                ""key"": ""IsAppModuleContext"",
+                ""value"": false
+            },
+            {
+                ""key"": ""AppModuleId"",
+                ""value"": ""00000000-0000-0000-0000-000000000000""
+            }
+        ],
+        ""IsExecutingOffline"": false,
+        ""IsInTransaction"": false,
+        ""IsOfflinePlayback"": false,
+        ""IsolationMode"": 1,
+        ""MessageName"": ""Create"",
+        ""Mode"": 1,
+        ""OperationCreatedOn"": ""\/Date(1737024736000+0200)\/"",
+        ""OperationId"": ""203839b3-08d4-ef11-aeb0-00155d000101"",
+        ""OrganizationId"": ""f0aabb07-b0c9-4cfe-80be-8effd49bf067"",
+        ""OrganizationName"": ""ORG"",
+        ""OutputParameters"": [],
+        ""OwningExtension"": {
+            ""Id"": ""ffd3ea1c-46ae-ef11-8a69-002248e53d94"",
+            ""KeyAttributes"": [],
+            ""LogicalName"": ""sdkmessageprocessingstep"",
+            ""Name"": null,
+            ""RowVersion"": null
+        },
+        ""ParentContext"": null,
+        ""PostEntityImages"": [],
+        ""PreEntityImages"": [],
+        ""PrimaryEntityId"": ""1e3839b3-08d4-ef11-aeb0-00155d000101"",
+        ""PrimaryEntityName"": ""sharepointdocument"",
+        ""RequestId"": ""e28dd17d-f8ee-4830-849d-8f9441ecac76"",
+        ""SecondaryEntityName"": ""none"",
+        ""SharedVariables"": [
+            {
+                ""key"": ""IsAutoTransact"",
+                ""value"": false
+            }
+        ],
+        ""Stage"": 30,
+        ""UserAzureActiveDirectoryObjectId"": ""00000000-0000-0000-0000-000000000000"",
+        ""UserId"": ""30c91177-9436-4042-ad53-dd966d490114""
+    },
+    ""PostEntityImages"": [
+        {
+            ""key"": ""PostImage"",
+            ""value"": {
+                ""Attributes"": [
+                    {
+                        ""key"": ""name"",
+                        ""value"": ""Documents on Default Site 1""
+                    },
+                    {
+                        ""key"": ""ownerid"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""30c91177-9436-4042-ad53-dd966d490114"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""systemuser"",
+                            ""Name"": ""Name"",
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""parentsiteorlocation"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""90fe6740-1cc1-e211-be17-000c29fb9e40"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""sharepointdocumentlocation"",
+                            ""Name"": ""account"",
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""regardingobjectid"",
+                        ""value"": {
+                            ""__type"": ""EntityReference:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Id"": ""0a3839b3-08d4-ef11-aeb0-00155d000101"",
+                            ""KeyAttributes"": [],
+                            ""LogicalName"": ""account"",
+                            ""Name"": ""Mini test"",
+                            ""RowVersion"": null
+                        }
+                    },
+                    {
+                        ""key"": ""relativeurl"",
+                        ""value"": ""Mini test""
+                    },
+                    {
+                        ""key"": ""sharepointdocumentlocationid"",
+                        ""value"": ""1e3839b3-08d4-ef11-aeb0-00155d000101""
+                    },
+                    {
+                        ""key"": ""statecode"",
+                        ""value"": {
+                            ""__type"": ""OptionSetValue:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Value"": 0
+                        }
+                    },
+                    {
+                        ""key"": ""statuscode"",
+                        ""value"": {
+                            ""__type"": ""OptionSetValue:http:\/\/schemas.microsoft.com\/xrm\/2011\/Contracts"",
+                            ""Value"": 1
+                        }
+                    }
+                ],
+                ""EntityState"": null,
+                ""FormattedValues"": [
+                    {
+                        ""key"": ""ownerid"",
+                        ""value"": ""Name""
+                    },
+                    {
+                        ""key"": ""parentsiteorlocation"",
+                        ""value"": ""account""
+                    },
+                    {
+                        ""key"": ""regardingobjectid"",
+                        ""value"": ""Mini test""
+                    },
+                    {
+                        ""key"": ""statecode"",
+                        ""value"": ""Active""
+                    },
+                    {
+                        ""key"": ""statuscode"",
+                        ""value"": ""Active""
+                    }
+                ],
+                ""Id"": ""1e3839b3-08d4-ef11-aeb0-00155d000101"",
+                ""KeyAttributes"": [],
+                ""LogicalName"": ""sharepointdocumentlocation"",
+                ""RelatedEntities"": [],
+                ""RowVersion"": null
+            }
+        },
+        {
+            ""key"": ""AsynchronousStepPrimaryName"",
+            ""value"": {
+                ""Attributes"": [
+                    {
+                        ""key"": ""name"",
+                        ""value"": ""Documents on Default Site 1""
+                    },
+                    {
+                        ""key"": ""sharepointdocumentlocationid"",
+                        ""value"": ""1e3839b3-08d4-ef11-aeb0-00155d000101""
+                    }
+                ],
+                ""EntityState"": null,
+                ""FormattedValues"": [],
+                ""Id"": ""1e3839b3-08d4-ef11-aeb0-00155d000101"",
+                ""KeyAttributes"": [],
+                ""LogicalName"": ""sharepointdocumentlocation"",
+                ""RelatedEntities"": [],
+                ""RowVersion"": null
+            }
+        }
+    ],
+    ""PreEntityImages"": [],
+    ""PrimaryEntityId"": ""1e3839b3-08d4-ef11-aeb0-00155d000101"",
+    ""PrimaryEntityName"": ""sharepointdocumentlocation"",
+    ""RequestId"": ""e28dd17d-f8ee-4830-849d-8f9441ecac76"",
+    ""SecondaryEntityName"": ""none"",
+    ""SharedVariables"": [
+        {
+            ""key"": ""IsAutoTransact"",
+            ""value"": true
+        },
+        {
+            ""key"": ""DefaultsAddedFlag"",
+            ""value"": true
+        }
+    ],
+    ""Stage"": 40,
+    ""UserAzureActiveDirectoryObjectId"": ""00000000-0000-0000-0000-000000000000"",
+    ""UserId"": ""30c91177-9436-4042-ad53-dd966d490114""
+}
+";
+            var remoteExecutionContext = EntitySerializer.Deserialize<RemoteExecutionContext>(serializedContext);
+        }
     }
 }

--- a/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/ColumnSetConverterTests.cs
+++ b/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/ColumnSetConverterTests.cs
@@ -42,14 +42,14 @@ namespace JsonConvertersTests
         {
             var entitySerializerOptions = new EntitySerializerOptions()
             {
-                WriteSchema = WriteSchemaOptions.Never
+                WriteSchema = WriteSchemaOptions.IfNeeded
             };
             // Arrange
             var columnSet = new ColumnSet(true);
             columnSet.AddColumn("column1");
             columnSet.AddColumn("column2");
             columnSet.AddColumn("column3");
-            var json = "{\"AllColumns\":true,\"Columns\":[\"column1\",\"column2\",\"column3\"],\"AttributeExpressions\":[]}";
+            var json = "{\"AllColumns\":true,\"AttributeExpressions\":[],\"Columns\":[\"column1\",\"column2\",\"column3\"]}";
             // Act
             var entitySerializer = EntitySerializer.Serialize(columnSet, typeof(ColumnSet), entitySerializerOptions);
             // Assert
@@ -72,7 +72,7 @@ namespace JsonConvertersTests
             columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute2", XrmAggregateType.Sum, "alias2"));
             columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute3", XrmAggregateType.Avg, "alias3") { HasGroupBy = true });
             columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute4", XrmAggregateType.Max, "alias4", XrmDateTimeGrouping.Month));
-            var json = "{\"AllColumns\":true,\"Columns\":[\"column1\",\"column2\",\"column3\"],\"AttributeExpressions\":[{\"AttributeName\":\"attribute1\",\"AggregateType\":0,\"Alias\":null,\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute2\",\"AggregateType\":3,\"Alias\":\"alias2\",\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute3\",\"AggregateType\":4,\"Alias\":\"alias3\",\"HasGroupBy\":true,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute4\",\"AggregateType\":6,\"Alias\":\"alias4\",\"HasGroupBy\":false,\"DateTimeGrouping\":3,\"ExtensionData\":null}]}";
+            var json = "{\"AllColumns\":true,\"AttributeExpressions\":[{\"AttributeName\":\"attribute1\",\"AggregateType\":0,\"Alias\":null,\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute2\",\"AggregateType\":3,\"Alias\":\"alias2\",\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute3\",\"AggregateType\":4,\"Alias\":\"alias3\",\"HasGroupBy\":true,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute4\",\"AggregateType\":6,\"Alias\":\"alias4\",\"HasGroupBy\":false,\"DateTimeGrouping\":3,\"ExtensionData\":null}],\"Columns\":[\"column1\",\"column2\",\"column3\"]}";
             // Act
             var entitySerializer = EntitySerializer.Serialize(columnSet, typeof(ColumnSet), entitySerializerOptions);
             var jsonSerializer = JsonSerializer.Serialize(columnSet);

--- a/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/ColumnSetConverterTests.cs
+++ b/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/ColumnSetConverterTests.cs
@@ -1,0 +1,135 @@
+﻿using AlbanianXrm.PowerPlatform;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JsonConvertersTests
+{
+    public class ColumnSetConverterTests
+    {
+        public ColumnSetConverterTests(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
+        public ITestOutputHelper Output { get; }
+
+        [Fact]
+        public void ColumnSetConverter_Read()
+        {
+            // Arrange
+            var columnSet = new ColumnSet(true);
+            columnSet.AddColumn("column1");
+            columnSet.AddColumn("column2");
+            columnSet.AddColumn("column3");
+            var json = "{\"AllColumns\":true,\"Columns\":[\"column1\",\"column2\",\"column3\"]}";
+            // Act
+            var result = EntitySerializer.Deserialize<ColumnSet>(json);
+            // Assert
+            Assert.Equal(columnSet.AllColumns, result.AllColumns);
+            Assert.Collection(result.Columns,
+                item => Assert.Equal("column1", item),
+                item => Assert.Equal("column2", item),
+                item => Assert.Equal("column3", item));
+        }
+
+        [Fact]
+        public void ColumnSetConverter_AddColumn_Write()
+        {
+            var entitySerializerOptions = new EntitySerializerOptions()
+            {
+                WriteSchema = WriteSchemaOptions.Never
+            };
+            // Arrange
+            var columnSet = new ColumnSet(true);
+            columnSet.AddColumn("column1");
+            columnSet.AddColumn("column2");
+            columnSet.AddColumn("column3");
+            var json = "{\"AllColumns\":true,\"Columns\":[\"column1\",\"column2\",\"column3\"],\"AttributeExpressions\":[]}";
+            // Act
+            var entitySerializer = EntitySerializer.Serialize(columnSet, typeof(ColumnSet), entitySerializerOptions);
+            // Assert
+            Assert.Equal(json, entitySerializer);
+        }
+
+        [Fact]
+        public void ColumnSetConverter_AttributeExpressions_Read()
+        {
+            var entitySerializerOptions = new EntitySerializerOptions()
+            {
+                WriteSchema = WriteSchemaOptions.Never
+            };
+            // Arrange
+            var columnSet = new ColumnSet(true);
+            columnSet.AddColumn("column1");
+            columnSet.AddColumn("column2");
+            columnSet.AddColumn("column3");
+            columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute1"));
+            columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute2", XrmAggregateType.Sum, "alias2"));
+            columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute3", XrmAggregateType.Avg, "alias3") { HasGroupBy = true });
+            columnSet.AttributeExpressions.Add(new XrmAttributeExpression("attribute4", XrmAggregateType.Max, "alias4", XrmDateTimeGrouping.Month));
+            var json = "{\"AllColumns\":true,\"Columns\":[\"column1\",\"column2\",\"column3\"],\"AttributeExpressions\":[{\"AttributeName\":\"attribute1\",\"AggregateType\":0,\"Alias\":null,\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute2\",\"AggregateType\":3,\"Alias\":\"alias2\",\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute3\",\"AggregateType\":4,\"Alias\":\"alias3\",\"HasGroupBy\":true,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute4\",\"AggregateType\":6,\"Alias\":\"alias4\",\"HasGroupBy\":false,\"DateTimeGrouping\":3,\"ExtensionData\":null}]}";
+            // Act
+            var entitySerializer = EntitySerializer.Serialize(columnSet, typeof(ColumnSet), entitySerializerOptions);
+            var jsonSerializer = JsonSerializer.Serialize(columnSet);
+            // Assert
+            Assert.Equal(json, entitySerializer);
+        }
+
+        [Fact]
+        public void ColumnSetConverter_AttributeExpressions_Write()
+        {
+            var entitySerializerOptions = new EntitySerializerOptions()
+            {
+                WriteSchema = WriteSchemaOptions.Never
+            };
+            // Arrange
+            var json = "{\"AllColumns\":true,\"Columns\":[\"column1\",\"column2\",\"column3\"],\"AttributeExpressions\":[{\"AttributeName\":\"attribute1\",\"AggregateType\":0,\"Alias\":null,\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute2\",\"AggregateType\":3,\"Alias\":\"alias2\",\"HasGroupBy\":true,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute3\",\"AggregateType\":4,\"Alias\":\"alias3\",\"HasGroupBy\":false,\"DateTimeGrouping\":0,\"ExtensionData\":null},{\"AttributeName\":\"attribute4\",\"AggregateType\":6,\"Alias\":\"alias4\",\"HasGroupBy\":false,\"DateTimeGrouping\":3,\"ExtensionData\":null}]}";
+            // Act
+            var result = EntitySerializer.Deserialize<ColumnSet>(json);
+            // Assert
+            Assert.True(result.AllColumns);
+            Assert.Collection(result.Columns,
+                item => Assert.Equal("column1", item),
+                item => Assert.Equal("column2", item),
+                item => Assert.Equal("column3", item));
+            Assert.Collection(result.AttributeExpressions,
+                item =>
+                {
+                    Assert.Equal("attribute1", item.AttributeName);
+                    Assert.Equal(XrmAggregateType.None, item.AggregateType);
+                    Assert.Null(item.Alias);
+                    Assert.False(item.HasGroupBy);
+                    Assert.Equal(XrmDateTimeGrouping.None, item.DateTimeGrouping);
+                },
+                item =>
+                {
+                    Assert.Equal("attribute2", item.AttributeName);
+                    Assert.Equal(XrmAggregateType.Sum, item.AggregateType);
+                    Assert.Equal("alias2", item.Alias);
+                    Assert.True(item.HasGroupBy);
+                    Assert.Equal(XrmDateTimeGrouping.None, item.DateTimeGrouping);
+                },
+                item =>
+                {
+                    Assert.Equal("attribute3", item.AttributeName);
+                    Assert.Equal(XrmAggregateType.Avg, item.AggregateType);
+                    Assert.Equal("alias3", item.Alias);
+                    Assert.False(item.HasGroupBy);
+                    Assert.Equal(XrmDateTimeGrouping.None, item.DateTimeGrouping);
+                },
+                item =>
+                {
+                    Assert.Equal("attribute4", item.AttributeName);
+                    Assert.Equal(XrmAggregateType.Max, item.AggregateType);
+                    Assert.Equal("alias4", item.Alias);
+                    Assert.False(item.HasGroupBy);
+                    Assert.Equal(XrmDateTimeGrouping.Month, item.DateTimeGrouping);
+                });
+        }
+    }
+}

--- a/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/QueryExpressionConverterTests.cs
+++ b/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/QueryExpressionConverterTests.cs
@@ -120,5 +120,210 @@ namespace JsonConvertersTests
             Assert.Equal(queryExpression.NoLock, result.NoLock);
             Assert.Equal(queryExpression.QueryHints, result.QueryHints);
         }
+
+        [Fact]
+        public void QueryExpression_Write()
+        {
+            // Arrange
+            var queryExpression = new QueryExpression("sharepointdocument")
+            {
+                ColumnSet = new ColumnSet(
+                    "documentid",
+                    "fullname",
+                    "relativelocation",
+                    "sharepointcreatedon",
+                    "ischeckedout",
+                    "filetype",
+                    "modified",
+                    "sharepointmodifiedby",
+                    "servicetype",
+                    "absoluteurl",
+                    "title",
+                    "author",
+                    "sharepointdocumentid",
+                    "readurl",
+                    "editurl",
+                    "locationid",
+                    "iconclassname",
+                    "locationname"),
+                Criteria = new FilterExpression(LogicalOperator.And)
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression("isrecursivefetch", ConditionOperator.Equal, false),
+                        new ConditionExpression("regardingobjecttypecode", ConditionOperator.Equal, 1),
+                        new ConditionExpression("regardingobjectid", ConditionOperator.Equal, "0a3839b3-08d4-ef11-aeb0-00155d000101")
+                    }
+                },
+                Distinct = false,
+                Orders = { new OrderExpression("relativelocation", OrderType.Ascending) },
+                PageInfo = new PagingInfo()
+                {
+                    Count = 10,
+                    PageNumber = 1,
+                    PagingCookie = null,
+                    ReturnTotalRecordCount = true
+                },
+                NoLock = false,
+                QueryHints = "",
+            };
+            var json = "{\"__type\":\"QueryExpression:http://schemas.microsoft.com/xrm/2011/Contracts\",\"ColumnSet\":{\"AllColumns\":false,\"AttributeExpressions\":[],\"Columns\":[\"documentid\",\"fullname\",\"relativelocation\",\"sharepointcreatedon\",\"ischeckedout\",\"filetype\",\"modified\",\"sharepointmodifiedby\",\"servicetype\",\"absoluteurl\",\"title\",\"author\",\"sharepointdocumentid\",\"readurl\",\"editurl\",\"locationid\",\"iconclassname\",\"locationname\"]},\"Criteria\":{\"Conditions\":[{\"AttributeName\":\"isrecursivefetch\",\"CompareColumns\":false,\"Operator\":0,\"Values\":[false],\"EntityName\":null},{\"AttributeName\":\"regardingobjecttypecode\",\"CompareColumns\":false,\"Operator\":0,\"Values\":[1],\"EntityName\":null},{\"AttributeName\":\"regardingobjectid\",\"CompareColumns\":false,\"Operator\":0,\"Values\":[\"0a3839b3-08d4-ef11-aeb0-00155d000101\"],\"EntityName\":null}],\"FilterOperator\":0,\"Filters\":[]},\"Distinct\":false,\"EntityName\":\"sharepointdocument\",\"LinkEntities\":[],\"Orders\":[{\"AttributeName\":\"relativelocation\",\"OrderType\":0,\"Alias\":null,\"EntityName\":null,\"ExtensionData\":null}],\"PageInfo\":{\"PageNumber\":1,\"Count\":10,\"ReturnTotalRecordCount\":true,\"PagingCookie\":null,\"ExtensionData\":null},\"NoLock\":false,\"QueryHints\":\"\"}";
+
+            // Act
+            var result = EntitySerializer.Serialize(queryExpression, typeof(QueryExpression), new EntitySerializerOptions()
+            {
+                WriteSchema = WriteSchemaOptions.IfNeeded
+            });
+            // Assert
+            Output.WriteLine($"Serialized result: {result}");
+            Assert.Equal(json, result);
+
+        }
+
+
+        [Fact]
+        public void QueryExpression_SerializeObject_Deserialize_Equals()
+        {
+            var queryExpression = new QueryExpression("account")
+            {
+                ColumnSet = new ColumnSet(true)
+                {
+                    Columns = { "name", "address1_city" }
+                },
+                Criteria = new FilterExpression(LogicalOperator.And)
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression("name", ConditionOperator.Equal, "Test"),
+                        new ConditionExpression("address1_city", ConditionOperator.Equal, "Redmond")
+                    }
+                },
+                PageInfo = new PagingInfo()
+                {
+                    Count = 10,
+                    PageNumber = 1,
+                    PagingCookie = null,
+                    ReturnTotalRecordCount = true
+                },
+                Orders = {
+                    new OrderExpression("name", OrderType.Ascending),
+                    new OrderExpression("createdon", OrderType.Descending)
+                },
+                NoLock = false,
+                Distinct = false,
+                LinkEntities =
+                {
+                    new LinkEntity("account", "contact", "primarycontactid", "contactid", JoinOperator.Inner)
+                    {
+                        Columns = new ColumnSet(true),
+                        EntityAlias = "contact",
+                        LinkCriteria = new FilterExpression(LogicalOperator.And)
+                        {
+                            Conditions =
+                            {
+                                new ConditionExpression("firstname", ConditionOperator.Equal, "John")
+                            }
+                        },
+                        LinkEntities = {
+                            new LinkEntity("contact", "account", "contactid", "primarycontactid", JoinOperator.Inner)
+                            {
+                                Columns = new ColumnSet(true),
+                                EntityAlias = "account",
+                                LinkCriteria = new FilterExpression(LogicalOperator.And)
+                                {
+                                    Conditions =
+                                    {
+                                        new ConditionExpression("name", ConditionOperator.Equal, "Test")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var json = EntitySerializer.Serialize(queryExpression, typeof(QueryExpression), new EntitySerializerOptions()
+            {
+                WriteSchema = WriteSchemaOptions.IfNeeded
+            });
+
+            var result = EntitySerializer.Deserialize<QueryExpression>(json);
+
+            Assert.Equal(queryExpression.EntityName, result.EntityName);
+            Assert.Equal(queryExpression.ColumnSet.AllColumns, result.ColumnSet.AllColumns);
+            Assert.Collection(result.ColumnSet.Columns,
+                item => Assert.Equal("name", item),
+                item => Assert.Equal("address1_city", item));
+            Assert.Equal(queryExpression.Criteria.Conditions.Count, result.Criteria.Conditions.Count);
+            Assert.Collection(result.Criteria.Conditions,
+                item =>
+                {
+                    Assert.Equal("name", item.AttributeName);
+                    Assert.Equal(ConditionOperator.Equal, item.Operator);
+                    Assert.Collection(item.Values, value => Assert.Equal("Test", value));
+                },
+                item =>
+                {
+                    Assert.Equal("address1_city", item.AttributeName);
+                    Assert.Equal(ConditionOperator.Equal, item.Operator);
+                    Assert.Collection(item.Values, value => Assert.Equal("Redmond", value));
+                });
+            Assert.Equal(queryExpression.Criteria.FilterOperator, result.Criteria.FilterOperator);
+            Assert.Equal(queryExpression.PageInfo.Count, result.PageInfo.Count);
+            Assert.Equal(queryExpression.PageInfo.PageNumber, result.PageInfo.PageNumber);
+            Assert.Equal(queryExpression.PageInfo.PagingCookie, result.PageInfo.PagingCookie);
+            Assert.Equal(queryExpression.PageInfo.ReturnTotalRecordCount, result.PageInfo.ReturnTotalRecordCount);
+            Assert.Equal(queryExpression.Orders.Count, result.Orders.Count);
+            Assert.Collection(result.Orders,
+                item => {
+                    Assert.Equal("name", item.AttributeName);
+                    Assert.Equal(OrderType.Ascending, item.OrderType);
+                },
+                item => {
+                    Assert.Equal("createdon", item.AttributeName);
+                    Assert.Equal(OrderType.Descending, item.OrderType);
+                });
+            Assert.Equal(queryExpression.NoLock, result.NoLock);
+            Assert.Equal(queryExpression.Distinct, result.Distinct);
+            Assert.Equal(queryExpression.LinkEntities.Count, result.LinkEntities.Count);
+            Assert.Collection(result.LinkEntities,
+                item =>
+                {
+                    Assert.Equal("account", item.LinkFromEntityName);
+                    Assert.Equal("contact", item.LinkToEntityName);
+                    Assert.Equal("primarycontactid", item.LinkFromAttributeName);
+                    Assert.Equal("contactid", item.LinkToAttributeName);
+                    Assert.Equal(JoinOperator.Inner, item.JoinOperator);
+                    Assert.Equal("contact", item.EntityAlias);
+                    Assert.Equal(queryExpression.LinkEntities[0].Columns.AllColumns, item.Columns.AllColumns);
+                    Assert.Equal(queryExpression.LinkEntities[0].LinkCriteria.FilterOperator, item.LinkCriteria.FilterOperator);
+                    Assert.Collection(item.LinkCriteria.Conditions,
+                        condition =>
+                        {
+                            Assert.Equal("firstname", condition.AttributeName);
+                            Assert.Equal(ConditionOperator.Equal, condition.Operator);
+                            Assert.Collection(condition.Values, value => Assert.Equal("John", value));
+                        });
+                    Assert.Collection(item.LinkEntities,
+                        subItem =>
+                        {
+                            Assert.Equal("contact", subItem.LinkFromEntityName);
+                            Assert.Equal("account", subItem.LinkToEntityName);
+                            Assert.Equal("contactid", subItem.LinkFromAttributeName);
+                            Assert.Equal("primarycontactid", subItem.LinkToAttributeName);
+                            Assert.Equal(JoinOperator.Inner, subItem.JoinOperator);
+                            Assert.Equal("account", subItem.EntityAlias);
+                            Assert.Equal(queryExpression.LinkEntities[0].LinkEntities[0].Columns.AllColumns, subItem.Columns.AllColumns);
+                            Assert.Equal(queryExpression.LinkEntities[0].LinkEntities[0].LinkCriteria.FilterOperator, subItem.LinkCriteria.FilterOperator);
+                            Assert.Collection(subItem.LinkCriteria.Conditions,
+                                condition =>
+                                {
+                                    Assert.Equal("name", condition.AttributeName);
+                                    Assert.Equal(ConditionOperator.Equal, condition.Operator);
+                                    Assert.Collection(condition.Values, value => Assert.Equal("Test", value));
+                                });
+                        });
+                });
+        }
     }
 }

--- a/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/QueryExpressionConverterTests.cs
+++ b/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/QueryExpressionConverterTests.cs
@@ -1,0 +1,124 @@
+﻿using AlbanianXrm.PowerPlatform;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Diagnostics;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JsonConvertersTests
+{
+    public class QueryExpressionConverterTests
+    {
+        public QueryExpressionConverterTests(ITestOutputHelper output)
+        {
+            Output = output;
+        }
+
+        public ITestOutputHelper Output { get; }
+
+        [Fact]
+        public void QueryExpression_Read()
+        {
+            // Arrange
+            var queryExpression = new QueryExpression("sharepointdocument")
+            {
+                ColumnSet = new ColumnSet(
+                    "documentid",
+                    "fullname",
+                    "relativelocation",
+                    "sharepointcreatedon",
+                    "ischeckedout",
+                    "filetype",
+                    "modified",
+                    "sharepointmodifiedby",
+                    "servicetype",
+                    "absoluteurl",
+                    "title",
+                    "author",
+                    "sharepointdocumentid",
+                    "readurl",
+                    "editurl",
+                    "locationid",
+                    "iconclassname",
+                    "locationname"),
+                Criteria = new FilterExpression(LogicalOperator.And)
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression("isrecursivefetch", ConditionOperator.Equal, false),
+                        new ConditionExpression("regardingobjecttypecode", ConditionOperator.Equal, 1),
+                        new ConditionExpression("regardingobjectid", ConditionOperator.Equal, "0a3839b3-08d4-ef11-aeb0-00155d000101")
+                    }
+                },
+                Distinct = false,
+                Orders = { new OrderExpression("relativelocation", OrderType.Ascending) },
+                PageInfo = new PagingInfo()
+                {
+                    Count = 10,
+                    PageNumber = 1,
+                    PagingCookie = null,
+                    ReturnTotalRecordCount = true
+                },
+                NoLock = false,
+                QueryHints = "",
+            };
+
+            var json = "{\"__type\":\"QueryExpression:http:\\/\\/schemas.microsoft.com\\/xrm\\/2011\\/Contracts\",\"ColumnSet\":{\"AllColumns\":false,\"AttributeExpressions\":[],\"Columns\":[\"documentid\",\"fullname\",\"relativelocation\",\"sharepointcreatedon\",\"ischeckedout\",\"filetype\",\"modified\",\"sharepointmodifiedby\",\"servicetype\",\"absoluteurl\",\"title\",\"author\",\"sharepointdocumentid\",\"readurl\",\"editurl\",\"locationid\",\"iconclassname\",\"locationname\"]},\"Criteria\":{\"Conditions\":[{\"AttributeName\":\"isrecursivefetch\",\"CompareColumns\":false,\"Operator\":0,\"Values\":[false],\"EntityName\":null},{\"AttributeName\":\"regardingobjecttypecode\",\"CompareColumns\":false,\"Operator\":0,\"Values\":[1],\"EntityName\":null},{\"AttributeName\":\"regardingobjectid\",\"CompareColumns\":false,\"Operator\":0,\"Values\":[\"0a3839b3-08d4-ef11-aeb0-00155d000101\"],\"EntityName\":null}],\"FilterOperator\":0,\"Filters\":[]},\"Distinct\":false,\"EntityName\":\"sharepointdocument\",\"LinkEntities\":[],\"Orders\":[{\"Alias\":null,\"AttributeName\":\"relativelocation\",\"OrderType\":0}],\"PageInfo\":{\"Count\":10,\"PageNumber\":1,\"PagingCookie\":null,\"ReturnTotalRecordCount\":true},\"NoLock\":false,\"QueryHints\":\"\"}";
+            // Act
+            var result = EntitySerializer.Deserialize<QueryExpression>(json);
+            // Assert
+            Assert.Equal(queryExpression.EntityName, result.EntityName);
+            Assert.Equal(queryExpression.ColumnSet.AllColumns, result.ColumnSet.AllColumns);
+            Assert.Collection(result.ColumnSet.Columns,
+                item => Assert.Equal("documentid", item),
+                item => Assert.Equal("fullname", item),
+                item => Assert.Equal("relativelocation", item),
+                item => Assert.Equal("sharepointcreatedon", item),
+                item => Assert.Equal("ischeckedout", item),
+                item => Assert.Equal("filetype", item),
+                item => Assert.Equal("modified", item),
+                item => Assert.Equal("sharepointmodifiedby", item),
+                item => Assert.Equal("servicetype", item),
+                item => Assert.Equal("absoluteurl", item),
+                item => Assert.Equal("title", item),
+                item => Assert.Equal("author", item),
+                item => Assert.Equal("sharepointdocumentid", item),
+                item => Assert.Equal("readurl", item),
+                item => Assert.Equal("editurl", item),
+                item => Assert.Equal("locationid", item),
+                item => Assert.Equal("iconclassname", item),
+                item => Assert.Equal("locationname", item));
+            Assert.Equal(queryExpression.Criteria.Conditions.Count, result.Criteria.Conditions.Count);
+            Assert.Collection(result.Criteria.Conditions,
+                item =>
+                {
+                    Assert.Equal("isrecursivefetch", item.AttributeName);
+                    Assert.Equal(ConditionOperator.Equal, item.Operator);
+                    Assert.Collection(item.Values, value => Assert.Equal(false, value));
+                },
+                item =>
+                {
+                    Assert.Equal("regardingobjecttypecode", item.AttributeName);
+                    Assert.Equal(ConditionOperator.Equal, item.Operator);
+                    Assert.Collection(item.Values, value => Assert.Equal(1, value));
+                },
+                item =>
+                {
+                    Assert.Equal("regardingobjectid", item.AttributeName);
+                    Assert.Equal(ConditionOperator.Equal, item.Operator);
+                    Assert.Collection(item.Values, value => Assert.Equal("0a3839b3-08d4-ef11-aeb0-00155d000101", value));
+                });
+            Assert.Equal(queryExpression.Distinct, result.Distinct);
+            Assert.Equal(queryExpression.Orders.Count, result.Orders.Count);
+            Assert.Collection(result.Orders,
+                item => Assert.Equal("relativelocation", item.AttributeName));
+            Assert.Equal(queryExpression.PageInfo.Count, result.PageInfo.Count);
+            Assert.Equal(queryExpression.PageInfo.PageNumber, result.PageInfo.PageNumber);
+            Assert.Equal(queryExpression.PageInfo.PagingCookie, result.PageInfo.PagingCookie);
+            Assert.Equal(queryExpression.PageInfo.ReturnTotalRecordCount, result.PageInfo.ReturnTotalRecordCount);
+            Assert.Equal(queryExpression.NoLock, result.NoLock);
+            Assert.Equal(queryExpression.QueryHints, result.QueryHints);
+        }
+    }
+}

--- a/PowerPlatform.EntitySerializer/EntitySerializer.cs
+++ b/PowerPlatform.EntitySerializer/EntitySerializer.cs
@@ -1,5 +1,6 @@
 ﻿using AlbanianXrm.PowerPlatform.JsonConverters;
 using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -93,21 +94,26 @@ namespace AlbanianXrm.PowerPlatform
             foreach (var item in jsonSerializerOptions.Converters)
             {
                 if (CanConvert<AttributeCollection>(item, entitySerializerOptions.converters) ||
+                    CanConvert<ColumnSet>(item, entitySerializerOptions.converters) ||
+                    CanConvert<ConditionExpression>(item, entitySerializerOptions.converters) ||
                     CanConvert<DateTime>(item, entitySerializerOptions.converters) ||
                     CanConvert<EntityCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<Entity>(item, entitySerializerOptions.converters) ||
                     CanConvert<EntityImageCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<EntityReference>(item, entitySerializerOptions.converters) ||
+                    CanConvert<FilterExpression>(item, entitySerializerOptions.converters) ||
                     CanConvert<FormattedValueCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<Guid>(item, entitySerializerOptions.converters) ||
                     CanConvert<KeyAttributeCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<IList<object>>(item, entitySerializerOptions.converters) ||
                     CanConvert<IList<Entity>>(item, entitySerializerOptions.converters) ||
+                    CanConvert<LinkEntity>(item, entitySerializerOptions.converters) ||
                     CanConvert<Money>(item, entitySerializerOptions.converters) ||
                     CanConvert<object>(item, entitySerializerOptions.converters) ||
                     CanConvert<OptionSetValue>(item, entitySerializerOptions.converters) ||
                     CanConvert<OptionSetValueCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<ParameterCollection>(item, entitySerializerOptions.converters) ||
+                    CanConvert<QueryExpression>(item, entitySerializerOptions.converters) ||
                     CanConvert<RelatedEntityCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<Relationship>(item, entitySerializerOptions.converters) ||
                     CanConvert<RemoteExecutionContext>(item, entitySerializerOptions.converters))
@@ -136,6 +142,16 @@ namespace AlbanianXrm.PowerPlatform
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
                     entitySerializerOptions.converters.Set(new AttributeCollectionConverter(entitySerializerOptions)));
             }
+            if (!entitySerializerOptions.converters.CanConvertType<ColumnSet>())
+            {
+                entitySerializerOptions.JsonSerializerOptions.Converters.Add(
+                    entitySerializerOptions.converters.Set(new ColumnSetConverter(entitySerializerOptions)));
+            }
+            if (!entitySerializerOptions.converters.CanConvertType<ConditionExpression>())
+            {
+                entitySerializerOptions.JsonSerializerOptions.Converters.Add(
+                    entitySerializerOptions.converters.Set(new ConditionExpressionConverter(entitySerializerOptions)));
+            }
             if (!entitySerializerOptions.converters.CanConvertType<DateTime>())
             {
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
@@ -161,6 +177,11 @@ namespace AlbanianXrm.PowerPlatform
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
                     entitySerializerOptions.converters.Set(new EntityReferenceConverter(entitySerializerOptions)));
             }
+            if (!entitySerializerOptions.converters.CanConvertType<FilterExpression>())
+            {
+                entitySerializerOptions.JsonSerializerOptions.Converters.Add(
+                    entitySerializerOptions.converters.Set(new FilterExpressionConverter(entitySerializerOptions)));
+            }
             if (!entitySerializerOptions.converters.CanConvertType<FormattedValueCollection>())
             {
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
@@ -180,6 +201,11 @@ namespace AlbanianXrm.PowerPlatform
             {
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
                     entitySerializerOptions.converters.Set(new KeyAttributeCollectionConverter(entitySerializerOptions)));
+            }
+            if (!entitySerializerOptions.converters.CanConvertType<LinkEntity>())
+            {
+                entitySerializerOptions.JsonSerializerOptions.Converters.Add(
+                    entitySerializerOptions.converters.Set(new LinkEntityConverter(entitySerializerOptions)));
             }
             if (!entitySerializerOptions.converters.CanConvertType<IList<object>>())
             {
@@ -210,6 +236,11 @@ namespace AlbanianXrm.PowerPlatform
             {
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
                     entitySerializerOptions.converters.Set(new ParameterCollectionConverter(entitySerializerOptions)));
+            }
+            if (!entitySerializerOptions.converters.CanConvertType<QueryExpression>())
+            {
+                entitySerializerOptions.JsonSerializerOptions.Converters.Add(
+                    entitySerializerOptions.converters.Set(new QueryExpressionConverter(entitySerializerOptions)));
             }
             if (!entitySerializerOptions.converters.CanConvertType<Relationship>())
             {

--- a/PowerPlatform.EntitySerializer/JsonConverters/ColumnSetConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/ColumnSetConverter.cs
@@ -88,22 +88,29 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
 
         public override void Write(Utf8JsonWriter writer, ColumnSet value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            if (entitySerializerOptions.writingSchema)
+            if (value == null)
             {
-                writer.WriteString(EntitySerializer.TypePropertyName, GetTypeSchema());
+                writer.WriteNullValue();
+                return;
+            }
+            writer.WriteStartObject();
+            if (entitySerializerOptions.writingSchema && entitySerializerOptions.WriteSchema != WriteSchemaOptions.IfNeeded)
+            {
+                writer.WriteString(EntitySerializer.TypePropertyName, TypeSchema);
             }
             writer.WriteBoolean(nameof(value.AllColumns), value.AllColumns);
-            writer.WriteStartArray(nameof(value.Columns));
-            foreach (var column in value.Columns)
-            {
-                writer.WriteStringValue(column);
-            }
-            writer.WriteEndArray();
+
             writer.WriteStartArray(nameof(value.AttributeExpressions));
             foreach (var attributeExpression in value.AttributeExpressions)
             {
                 JsonSerializer.Serialize(writer, attributeExpression, options);
+            }
+            writer.WriteEndArray();
+
+            writer.WriteStartArray(nameof(value.Columns));
+            foreach (var column in value.Columns)
+            {
+                writer.WriteStringValue(column);
             }
             writer.WriteEndArray();
             writer.WriteEndObject();

--- a/PowerPlatform.EntitySerializer/JsonConverters/ColumnSetConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/ColumnSetConverter.cs
@@ -1,0 +1,112 @@
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlbanianXrm.PowerPlatform.JsonConverters
+{
+    public class ColumnSetConverter : JsonConverter<ColumnSet>, IObjectContractConverter
+    {
+        public const string TypeSchema = "ColumnSet:http://schemas.microsoft.com/xrm/2011/Contracts";
+        private readonly EntitySerializerOptions entitySerializerOptions;
+        private JsonConverter<AttributeCollection> attributeCollectionConverter;
+        private JsonConverter<FormattedValueCollection> formattedValueCollectionConverter;
+        private JsonConverter<KeyAttributeCollection> keyAttributeCollectionConverter;
+        private JsonConverter<RelatedEntityCollection> relatedEntityCollectionConverter;
+
+        public ColumnSetConverter(EntitySerializerOptions entitySerializerOptions)
+        {
+            this.entitySerializerOptions = entitySerializerOptions;
+        }
+
+        public string GetTypeSchema() { return TypeSchema; }
+
+        public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var columnSet = new ColumnSet();
+
+            reader.Read();
+            while (reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    throw new JsonException();
+                }
+                string propertyName = reader.GetString();
+                reader.Read();
+                switch (propertyName)
+                {
+                    case EntitySerializer.TypePropertyName:
+                        reader.GetString(); // should check right type?
+                        break;
+                    case nameof(columnSet.AllColumns):
+                        columnSet.AllColumns = reader.GetBoolean();
+                        break;
+                    case nameof(columnSet.Columns):
+                        if (reader.TokenType == JsonTokenType.StartArray)
+                        {
+                            reader.Read();
+                            while (reader.TokenType != JsonTokenType.EndArray)
+                            {
+                                columnSet.Columns.Add(reader.GetString());
+                                reader.Read();
+                            }
+                        }
+                        break;
+                    case nameof(columnSet.AttributeExpressions):
+                        if (reader.TokenType == JsonTokenType.StartArray)
+                        {
+                            reader.Read();
+                            while (reader.TokenType != JsonTokenType.EndArray)
+                            {
+                                var attributeExpression = JsonSerializer.Deserialize<XrmAttributeExpression>(ref reader, options);
+                                columnSet.AttributeExpressions.Add(attributeExpression);
+                                reader.Read();
+                            }
+                        }
+                        break;
+                    default:
+                        throw new NotImplementedException($"Unknown property \"{propertyName}\" for ColumnSet type.");
+                }
+                if (!reader.Read())
+                {
+                    throw new JsonException();
+                }
+            }
+            return columnSet;
+        }
+
+        public override ColumnSet Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException();
+            }
+            return (ColumnSet)ReadInternal(ref reader, typeToConvert, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, ColumnSet value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            if (entitySerializerOptions.writingSchema)
+            {
+                writer.WriteString(EntitySerializer.TypePropertyName, GetTypeSchema());
+            }
+            writer.WriteBoolean(nameof(value.AllColumns), value.AllColumns);
+            writer.WriteStartArray(nameof(value.Columns));
+            foreach (var column in value.Columns)
+            {
+                writer.WriteStringValue(column);
+            }
+            writer.WriteEndArray();
+            writer.WriteStartArray(nameof(value.AttributeExpressions));
+            foreach (var attributeExpression in value.AttributeExpressions)
+            {
+                JsonSerializer.Serialize(writer, attributeExpression, options);
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/PowerPlatform.EntitySerializer/JsonConverters/ConditionExpressionConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/ConditionExpressionConverter.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlbanianXrm.PowerPlatform.JsonConverters
+{
+    public class ConditionExpressionConverter : JsonConverter<ConditionExpression>, IObjectContractConverter
+    {
+        public const string TypeSchema = "ConditionExpression:http://schemas.microsoft.com/xrm/2011/Contracts";
+        private readonly EntitySerializerOptions entitySerializerOptions;
+        private JsonConverter<FilterExpression> filterExpressionConverter;
+        private JsonConverter<LinkEntity> linkEntityConverter;
+        private JsonConverter<object> objectContractConverter;
+        private JsonConverter<IList<object>> listOfObjectsConverter;
+
+        public string GetTypeSchema() { return TypeSchema; }
+
+        public ConditionExpressionConverter(EntitySerializerOptions entitySerializerOptions)
+        {
+            this.entitySerializerOptions = entitySerializerOptions;
+        }
+        public override ConditionExpression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject token");
+            }
+            return (ConditionExpression)ReadInternal(ref reader, typeToConvert, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, ConditionExpression value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+
+            var conditionExpression = new ConditionExpression();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return conditionExpression;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    string propertyName = reader.GetString();
+                    reader.Read();
+
+                    switch (propertyName)
+                    {
+                        case nameof(ConditionExpression.AttributeName):
+                            conditionExpression.AttributeName = reader.GetString();
+                            break;
+                        case nameof(ConditionExpression.Operator):
+                            conditionExpression.Operator = (ConditionOperator)reader.GetInt32();
+                            break;
+                        case nameof(ConditionExpression.EntityName):
+                            conditionExpression.EntityName = reader.GetString();
+                            break;
+                        case nameof(ConditionExpression.Values):
+                            if (reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    conditionExpression.Values.Add(ObjectContractConverter.ReadValue(ref reader, options, entitySerializerOptions, ref objectContractConverter, ref listOfObjectsConverter, null));
+                                }
+                            }
+                            break;
+                        case nameof(ConditionExpression.CompareColumns):
+                            conditionExpression.CompareColumns = reader.GetBoolean();
+                            break;
+                        default:
+                            throw new NotSupportedException($"Property {propertyName} not supported");
+                    }
+                }
+            }
+
+            throw new JsonException("Expected EndObject token");
+        }
+    }
+}

--- a/PowerPlatform.EntitySerializer/JsonConverters/ConditionExpressionConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/ConditionExpressionConverter.cs
@@ -33,7 +33,34 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
 
         public override void Write(Utf8JsonWriter writer, ConditionExpression value, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            writer.WriteStartObject();
+
+            if (value.AttributeName != null)
+            {
+                writer.WriteString(nameof(ConditionExpression.AttributeName), value.AttributeName);
+            }
+
+            writer.WriteBoolean(nameof(ConditionExpression.CompareColumns), value.CompareColumns);
+            writer.WriteNumber(nameof(ConditionExpression.Operator), (int)value.Operator);
+            if (value.Values != null && value.Values.Count > 0)
+            {
+                writer.WritePropertyName(nameof(ConditionExpression.Values));
+                writer.WriteStartArray();
+                foreach (var val in value.Values)
+                {
+                    JsonSerializer.Serialize(writer, val, options);
+                }
+                writer.WriteEndArray();
+            }
+
+            writer.WriteString(nameof(ConditionExpression.EntityName), value.EntityName);
+
+            writer.WriteEndObject();
         }
 
         public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/PowerPlatform.EntitySerializer/JsonConverters/DateTimeConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/DateTimeConverter.cs
@@ -75,6 +75,13 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
             }
         }
 
+        public static string ConvertToString(DateTime dateTime)
+        {
+            var milliseconds = (dateTime.ToUniversalTime() - epoch).TotalMilliseconds;
+            var offset = dateTime.ToString("zzz").Replace(":", "");
+            return $"/Date({milliseconds}{offset})/";
+        }
+
 
         public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/PowerPlatform.EntitySerializer/JsonConverters/FilterExpressionConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/FilterExpressionConverter.cs
@@ -28,7 +28,37 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
 
         public override void Write(Utf8JsonWriter writer, FilterExpression value, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(FilterExpression.Conditions));
+            writer.WriteStartArray();
+            foreach (var condition in value.Conditions)
+            {
+                JsonSerializer.Serialize(writer, condition, options);
+            }
+            writer.WriteEndArray();
+
+            writer.WritePropertyName(nameof(FilterExpression.FilterOperator));
+            writer.WriteNumberValue((int)value.FilterOperator);
+
+            writer.WritePropertyName(nameof(FilterExpression.Filters));
+            writer.WriteStartArray();
+            foreach (var filter in value.Filters)
+            {
+                JsonSerializer.Serialize(writer, filter, options);
+            }
+            writer.WriteEndArray();
+            if (value.IsQuickFindFilter == true) {
+                writer.WritePropertyName(nameof(FilterExpression.IsQuickFindFilter));
+            }
+
+            if (value.FilterHint != null)
+            {
+                writer.WritePropertyName(nameof(FilterExpression.FilterHint));
+                writer.WriteStringValue(value.FilterHint);
+            }
+
+            writer.WriteEndObject();
         }
 
         public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/PowerPlatform.EntitySerializer/JsonConverters/FilterExpressionConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/FilterExpressionConverter.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlbanianXrm.PowerPlatform.JsonConverters
+{
+    public class FilterExpressionConverter : JsonConverter<FilterExpression>, IObjectContractConverter
+    {
+        public const string TypeSchema = "FilterExpression:http://schemas.microsoft.com/xrm/2011/Contracts";
+        private readonly EntitySerializerOptions entitySerializerOptions;
+        private JsonConverter<FilterExpression> filterExpressionConverter;
+
+        public string GetTypeSchema() { return TypeSchema; }
+
+        public FilterExpressionConverter(EntitySerializerOptions entitySerializerOptions)
+        {
+            this.entitySerializerOptions = entitySerializerOptions;
+        }
+        public override FilterExpression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject token");
+            }
+            return (FilterExpression)ReadInternal(ref reader, typeToConvert, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, FilterExpression value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+
+            var filterExpression = new FilterExpression();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return filterExpression;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    string propertyName = reader.GetString();
+                    reader.Read();
+
+                    switch (propertyName)
+                    {
+                        case nameof(FilterExpression.FilterOperator):
+                            filterExpression.FilterOperator = (LogicalOperator)reader.GetInt32();
+                            break;
+                        case nameof(FilterExpression.Conditions):
+                            if (reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                reader.Read();
+                                while (reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    var conditionExpression = JsonSerializer.Deserialize<ConditionExpression>(ref reader, options);
+                                    filterExpression.Conditions.Add(conditionExpression);
+                                    reader.Read();
+                                }
+                            }
+                            break;
+                        case nameof(FilterExpression.Filters):
+                            if (reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                reader.Read();
+                                while (reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    if (filterExpressionConverter == null) { filterExpressionConverter = entitySerializerOptions.converters.GetForType<FilterExpression>(); }
+                                    var subFilterExpression = filterExpressionConverter.Read(ref reader, typeof(FilterExpression), options);
+                                    filterExpression.Filters.Add(subFilterExpression);
+                                }
+                            }
+                            break;
+                        case nameof(FilterExpression.IsQuickFindFilter):
+                            filterExpression.IsQuickFindFilter = reader.GetBoolean();
+                            break;
+                        case nameof(FilterExpression.FilterHint):
+                            filterExpression.FilterHint = reader.GetString();
+                            break;
+                        default:
+                            throw new NotImplementedException($"Unknown property \"{propertyName}\" for FilterExpression type.");
+                    }
+                }
+            }
+
+            throw new JsonException("Expected EndObject token");
+        }
+    }
+}

--- a/PowerPlatform.EntitySerializer/JsonConverters/IntegerConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/IntegerConverter.cs
@@ -44,6 +44,10 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
             {
                 return reader.GetInt32();
             }
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                return reader.GetInt32();
+            }
             else if (reader.TokenType == JsonTokenType.StartObject)
             {
                 reader.Read();

--- a/PowerPlatform.EntitySerializer/JsonConverters/LinkEntityConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/LinkEntityConverter.cs
@@ -33,7 +33,82 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
 
         public override void Write(Utf8JsonWriter writer, LinkEntity value, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+            writer.WriteStartObject();
+
+            if (value.Columns != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.Columns));
+                JsonSerializer.Serialize(writer, value.Columns, options);
+            }
+
+            if (value.EntityAlias != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.EntityAlias));
+                writer.WriteStringValue(value.EntityAlias);
+            }
+
+            writer.WritePropertyName(nameof(LinkEntity.JoinOperator));
+            writer.WriteNumberValue((int)value.JoinOperator);
+
+            if (value.LinkCriteria != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.LinkCriteria));
+                JsonSerializer.Serialize(writer, value.LinkCriteria, options);
+            }
+
+            if (value.LinkFromAttributeName != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.LinkFromAttributeName));
+                writer.WriteStringValue(value.LinkFromAttributeName);
+            }
+
+            if (value.LinkFromEntityName != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.LinkFromEntityName));
+                writer.WriteStringValue(value.LinkFromEntityName);
+            }
+
+            if (value.LinkToAttributeName != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.LinkToAttributeName));
+                writer.WriteStringValue(value.LinkToAttributeName);
+            }
+
+            if (value.LinkToEntityName != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.LinkToEntityName));
+                writer.WriteStringValue(value.LinkToEntityName);
+            }
+
+            if (value.LinkEntities != null && value.LinkEntities.Count > 0)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.LinkEntities));
+                writer.WriteStartArray();
+                foreach (var linkEntity in value.LinkEntities)
+                {
+                    JsonSerializer.Serialize(writer, linkEntity, options);
+                }
+                writer.WriteEndArray();
+            }
+
+            if (value.ForceSeek != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.ForceSeek));
+                writer.WriteStringValue(value.ForceSeek);
+            }
+
+            if (value.ExtensionData != null)
+            {
+                writer.WritePropertyName(nameof(LinkEntity.ExtensionData));
+                JsonSerializer.Serialize(writer, value.ExtensionData, options);
+            }
+
+            writer.WriteEndObject();
         }
 
         public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -84,15 +159,13 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
                         case nameof(LinkEntity.LinkEntities):
                             if (reader.TokenType == JsonTokenType.StartArray)
                             {
-                                reader.Read();
-                                while (reader.TokenType != JsonTokenType.EndArray)
+                                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
                                 {
                                     if (reader.TokenType != JsonTokenType.StartObject)
                                     {
                                         throw new JsonException("Expected StartObject token");
                                     }
                                     linkEntity.LinkEntities.Add((LinkEntity)ReadInternal(ref reader, typeof(LinkEntity), options));
-                                    reader.Read();
                                 }
                             }
                             break;
@@ -106,7 +179,6 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
                             throw new NotImplementedException($"Unknown property \"{propertyName}\" for LinkEntity type.");
                     }
                 }
-                return linkEntity;
             }
 
             throw new JsonException("Expected EndObject token");

--- a/PowerPlatform.EntitySerializer/JsonConverters/LinkEntityConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/LinkEntityConverter.cs
@@ -1,0 +1,115 @@
+﻿
+
+
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlbanianXrm.PowerPlatform.JsonConverters
+{
+    public class LinkEntityConverter : JsonConverter<LinkEntity>, IObjectContractConverter
+    {
+        public const string TypeSchema = "LinkEntity:http://schemas.microsoft.com/xrm/2011/Contracts";
+        private readonly EntitySerializerOptions entitySerializerOptions;
+        private JsonConverter<FilterExpression> filterExpressionConverter;
+        private JsonConverter<ColumnSet> columnSetConverter;
+
+        public string GetTypeSchema() { return TypeSchema; }
+
+        public LinkEntityConverter(EntitySerializerOptions entitySerializerOptions)
+        {
+            this.entitySerializerOptions = entitySerializerOptions;
+        }
+        public override LinkEntity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject token");
+            }
+            return (LinkEntity)ReadInternal(ref reader, typeToConvert, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, LinkEntity value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+
+            var linkEntity = new LinkEntity();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return linkEntity;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    string propertyName = reader.GetString();
+                    reader.Read();
+
+                    switch (propertyName)
+                    {
+                        case nameof(LinkEntity.Columns):
+                            if (columnSetConverter == null) { columnSetConverter = entitySerializerOptions.converters.GetForType<ColumnSet>(); }
+                            linkEntity.Columns = columnSetConverter.Read(ref reader, typeof(ColumnSet), options);
+                            break;
+                        case nameof(LinkEntity.EntityAlias):
+                            linkEntity.EntityAlias = reader.GetString();
+                            break;
+                        case nameof(LinkEntity.JoinOperator):
+                            linkEntity.JoinOperator = (JoinOperator)reader.GetInt32();
+                            break;
+                        case nameof(LinkEntity.LinkCriteria):
+                            if (filterExpressionConverter == null) { filterExpressionConverter = entitySerializerOptions.converters.GetForType<FilterExpression>(); }
+                            linkEntity.LinkCriteria = filterExpressionConverter.Read(ref reader, typeof(FilterExpression), options);
+                            break;
+                        case nameof(LinkEntity.LinkFromAttributeName):
+                            linkEntity.LinkFromAttributeName = reader.GetString();
+                            break;
+                        case nameof(LinkEntity.LinkFromEntityName):
+                            linkEntity.LinkFromEntityName = reader.GetString();
+                            break;
+                        case nameof(LinkEntity.LinkToAttributeName):
+                            linkEntity.LinkToAttributeName = reader.GetString();
+                            break;
+                        case nameof(LinkEntity.LinkToEntityName):
+                            linkEntity.LinkToEntityName = reader.GetString();
+                            break;
+                        case nameof(LinkEntity.LinkEntities):
+                            if (reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                reader.Read();
+                                while (reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    if (reader.TokenType != JsonTokenType.StartObject)
+                                    {
+                                        throw new JsonException("Expected StartObject token");
+                                    }
+                                    linkEntity.LinkEntities.Add((LinkEntity)ReadInternal(ref reader, typeof(LinkEntity), options));
+                                    reader.Read();
+                                }
+                            }
+                            break;
+                        case nameof(LinkEntity.ForceSeek):
+                            linkEntity.ForceSeek = reader.GetString();
+                            break;
+                        case nameof(LinkEntity.ExtensionData):
+                            linkEntity.ExtensionData = JsonSerializer.Deserialize<ExtensionDataObject>(ref reader, options);
+                            break;
+                        default:
+                            throw new NotImplementedException($"Unknown property \"{propertyName}\" for LinkEntity type.");
+                    }
+                }
+                return linkEntity;
+            }
+
+            throw new JsonException("Expected EndObject token");
+        }
+    }
+}

--- a/PowerPlatform.EntitySerializer/JsonConverters/ObjectContractConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/ObjectContractConverter.cs
@@ -133,8 +133,51 @@ namespace AlbanianXrm.PowerPlatform.JsonConverters
 
         public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
         {
-            writer.WriteStartObject();
-            writer.WriteEndObject();
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            switch (value)
+            {
+                case bool boolValue:
+                    writer.WriteBooleanValue(boolValue);
+                    break;
+                case int intValue:
+                    writer.WriteNumberValue(intValue);
+                    break;
+                case decimal decimalValue:
+                    writer.WriteNumberValue(decimalValue);
+                    break;
+                case string stringValue:
+                    writer.WriteStringValue(stringValue);
+                    break;
+                case Guid guidValue:
+                    writer.WriteStringValue(guidValue);
+                    break;
+                case DateTime dateTimeValue:
+                    writer.WriteStringValue(DateTimeConverter.ConvertToString(dateTimeValue));
+                    break;
+                case IList<object> listValue:
+                    JsonConverter<IList<object>> listConverter = entitySerializerOptions.converters.GetForType<IList<object>>();
+                    listConverter.Write(writer, listValue, options);
+                    break;
+                case Dictionary<string, object> dictValue:
+                    writer.WriteStartObject();
+                    foreach (var kvp in dictValue)
+                    {
+                        writer.WritePropertyName(kvp.Key);
+                        Write(writer, kvp.Value, options);
+                    }
+                    writer.WriteEndObject();
+                    break;
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                default:
+                    throw new JsonException($"We don'tknow how to handle value of type {value.GetType().Name}");
+            }
         }
     }
 }

--- a/PowerPlatform.EntitySerializer/JsonConverters/QueryExpressionConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/QueryExpressionConverter.cs
@@ -1,0 +1,115 @@
+﻿using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlbanianXrm.PowerPlatform.JsonConverters
+{
+    public class QueryExpressionConverter : JsonConverter<QueryExpression>, IObjectContractConverter
+    {
+        public const string TypeSchema = "QueryExpression:http://schemas.microsoft.com/xrm/2011/Contracts";
+        private readonly EntitySerializerOptions entitySerializerOptions;
+        private JsonConverter<ColumnSet> columnSetConverter;
+        private JsonConverter<FilterExpression> filterExpressionConverter;
+        private JsonConverter<LinkEntity> linkEntityConverter;
+
+        public string GetTypeSchema() { return TypeSchema; }
+
+        public QueryExpressionConverter(EntitySerializerOptions entitySerializerOptions)
+        {
+            this.entitySerializerOptions = entitySerializerOptions;
+        }
+        public override QueryExpression Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException("Expected StartObject token");
+            }
+            return (QueryExpression)ReadInternal(ref reader, typeToConvert, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, QueryExpression value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteEndObject();
+        }
+
+        public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+
+            var queryExpression = new QueryExpression();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    return queryExpression;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    string propertyName = reader.GetString();
+                    reader.Read();
+
+                    switch (propertyName)
+                    {
+                        case nameof(QueryExpression.EntityName):
+                            queryExpression.EntityName = reader.GetString();
+                            break;
+                        case nameof(QueryExpression.ColumnSet):
+                            if (columnSetConverter == null) columnSetConverter = entitySerializerOptions.converters.GetForType<ColumnSet>();
+                            queryExpression.ColumnSet = columnSetConverter.Read(ref reader, typeof(ColumnSet), options);
+                            break;
+                        case nameof(QueryExpression.Criteria):
+                            if (filterExpressionConverter == null) filterExpressionConverter = entitySerializerOptions.converters.GetForType<FilterExpression>();
+                            queryExpression.Criteria = filterExpressionConverter.Read(ref reader, typeof(FilterExpression), options);
+                            break;
+                        case nameof(QueryExpression.Orders):
+                            if (reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    var orderExpression = JsonSerializer.Deserialize<OrderExpression>(ref reader, options);
+                                    queryExpression.Orders.Add(orderExpression);
+                                }
+                            }
+                            break;
+                        case nameof(QueryExpression.PageInfo):
+                            queryExpression.PageInfo = JsonSerializer.Deserialize<PagingInfo>(ref reader, options);
+                            break;
+                        case nameof(QueryExpression.TopCount):
+                            queryExpression.TopCount = reader.GetInt32();
+                            break;
+                        case nameof(QueryExpression.Distinct):
+                            queryExpression.Distinct = reader.GetBoolean();
+                            break;
+                        case nameof(QueryExpression.LinkEntities):
+                            if (linkEntityConverter == null) linkEntityConverter = entitySerializerOptions.converters.GetForType<LinkEntity>();
+                            if (reader.TokenType == JsonTokenType.StartArray)
+                            {
+                                reader.Read();
+                                while (reader.TokenType != JsonTokenType.EndArray)
+                                {
+                                    var linkEntity = linkEntityConverter.Read(ref reader, typeof(LinkEntity), options);
+                                    queryExpression.LinkEntities.Add(linkEntity);
+                                    reader.Read();
+                                }
+                            }
+                            break;
+                        case nameof(QueryExpression.NoLock):
+                            queryExpression.NoLock = reader.GetBoolean();
+                            break;
+                        case nameof(QueryExpression.QueryHints):
+                            queryExpression.QueryHints = reader.GetString();
+                            break;
+                        default:
+                            reader.Skip();
+                            break;
+                    }
+                }
+            }
+
+            throw new JsonException("Expected EndObject token");
+        }
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,7 @@ steps:
     packagesToPack: PowerPlatform.EntitySerializer.Sources\PowerPlatform.EntitySerializer.Sources.nuspec
     versioningScheme: byEnvVar
     versionEnvVar: MyVars.BuildNumber
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
 - task: CopyFiles@2
   displayName: 'Preparing NuGet packages'
@@ -114,3 +115,4 @@ steps:
   inputs:
     pathToPublish:  '$(Build.ArtifactStagingDirectory)\NuGets'
     ArtifactName: 'NuGets' 
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))


### PR DESCRIPTION
Adding sdkprocessingstep for sharepointdocumentlocation entity somehow gets me a parent context with a QueryExpression. Such message couldn't be deserializet. The message is added to Test `DeserializeRemoteExecutionContextWithDocumentLocation`

I Implemented deserialization (and serialization) logic for QueryExpression and added some tests to validate the functionality.

Ultimately, `DeserializeRemoteExecutionContextWithDocumentLocation` test passes.

P.S. Note that in `IntegerConverter.cs` I maybe found a bug where it tried to match string when reading Int32... I did not know whether to discard the `if (reader.TokenType == JsonTokenType.String)`... I was careful and added additional `if (reader.TokenType == JsonTokenType.Number)` case which seems appropriate for `IntegerConvertor`
https://github.com/albanian-xrm/PowerPlatform-Entity-Serializer/compare/main...janis-veinbergs:PowerPlatform-Entity-Serializer:dev?expand=1#diff-0b652c19b40d1413fc2e04f3ae1f312dd47028ef3f96459ee371215d920e1cf7R47-R50
