### PR TITLE
Support Double serialization/deserialization

### DIFF
--- a/PowerPlatform.EntitySerializer.Sources/PowerPlatform.EntitySerializer.Sources.nuspec
+++ b/PowerPlatform.EntitySerializer.Sources/PowerPlatform.EntitySerializer.Sources.nuspec
@@ -15,10 +15,7 @@
 		<description>Source Nuget package for serializing an Entity using System.Text.JSON.</description>
 		<releaseNotes>
 			v$version$:
-			- DateOptions now allow you to instruct to serialize in Xrm Unix timestamp format
-			- Fixes Schema writing for IfNeeded for multiple types
-			- Fix: OptionSetValueCollectionConverter doesn't write StartArray
-			- Write Enums
+			- Support Double serialization/deserialization.
 			* thnx. Jānis Veinbergs
 		</releaseNotes>
 		<copyright>Copyright 2025</copyright>

--- a/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/EntityConverterTests.cs
+++ b/PowerPlatform.EntitySerializer.Tests/JsonConvetersTests/EntityConverterTests.cs
@@ -91,5 +91,67 @@ namespace JsonConvertersTests
             };
             Assert.Throws<JsonException>(() => EntitySerializer.Deserialize<Entity>(input, entitySerializerOptions));
         }
+
+        [Fact]
+        public void EntityCanBeSerializedWithDouble()
+        {
+            var entity = new Entity()
+            {
+                Attributes = new AttributeCollection()
+                {
+                    { "double", 123.345d },
+                    { "decimal", 345.567m },
+                    { "double_maxvalue", Double.MaxValue },
+                    { "double_minvalue", Double.MinValue },
+                    { "decimal_maxvalue", Decimal.MaxValue },
+                    { "decimal_minvalue", Decimal.MinValue }
+                }
+            };
+            var entitySerializerOptions = new EntitySerializerOptions();
+            var serializedEntity = EntitySerializer.Serialize(entity, typeof(Entity), entitySerializerOptions);
+            output.WriteLine(serializedEntity);
+            Assert.Equal("{\"__type\":\"Entity:http://schemas.microsoft.com/xrm/2011/Contracts\",\"Attributes\":[{\"key\":\"double\",\"value\":{\"__type\":\"Double:#System\",\"__value\":123.345}},{\"key\":\"decimal\",\"value\":345.567},{\"key\":\"double_maxvalue\",\"value\":{\"__type\":\"Double:#System\",\"__value\":1.7976931348623157E+308}},{\"key\":\"double_minvalue\",\"value\":{\"__type\":\"Double:#System\",\"__value\":-1.7976931348623157E+308}},{\"key\":\"decimal_maxvalue\",\"value\":79228162514264337593543950335},{\"key\":\"decimal_minvalue\",\"value\":-79228162514264337593543950335}],\"EntityState\":null,\"FormattedValues\":[],\"Id\":\"00000000-0000-0000-0000-000000000000\",\"KeyAttributes\":[],\"LogicalName\":null,\"RelatedEntities\":[],\"RowVersion\":null}", serializedEntity);
+
+            var deserializedEntity = EntitySerializer.Deserialize<Entity>(serializedEntity, entitySerializerOptions);
+            Assert.Equal(123.345d, deserializedEntity.GetAttributeValue<double>("double"));
+            Assert.Equal(345.567m, deserializedEntity.GetAttributeValue<decimal>("decimal")); 
+            Assert.Equal(Double.MaxValue, deserializedEntity.GetAttributeValue<double>("double_maxvalue"));
+            Assert.Equal(Double.MinValue, deserializedEntity.GetAttributeValue<double>("double_minvalue"));
+            Assert.Equal(Decimal.MaxValue, deserializedEntity.GetAttributeValue<decimal>("decimal_maxvalue"));
+            Assert.Equal(Decimal.MinValue, deserializedEntity.GetAttributeValue<decimal>("decimal_minvalue"));
+        }
+
+        [Fact]
+        public void EntityCanBeSerializedWithDouble_NoSchema_DecimalDefault()
+        {
+            var entity = new Entity()
+            {
+                Attributes = new AttributeCollection()
+                {
+                    { "double", 123.345d },
+                    { "decimal", 345.567m },
+                    { "double_maxvalue", Double.MaxValue },
+                    { "double_minvalue", Double.MinValue },
+                    { "decimal_maxvalue", Decimal.MaxValue },
+                    { "decimal_minvalue", Decimal.MinValue }
+                }
+            };
+            var entitySerializerOptions = new EntitySerializerOptions()
+            {
+                WriteSchema = WriteSchemaOptions.Never
+            };
+            var serializedEntity = EntitySerializer.Serialize(entity, typeof(Entity), entitySerializerOptions);
+            output.WriteLine(serializedEntity);
+            Assert.Equal("{\"Attributes\":[{\"key\":\"double\",\"value\":123.345},{\"key\":\"decimal\",\"value\":345.567},{\"key\":\"double_maxvalue\",\"value\":1.7976931348623157E+308},{\"key\":\"double_minvalue\",\"value\":-1.7976931348623157E+308},{\"key\":\"decimal_maxvalue\",\"value\":79228162514264337593543950335},{\"key\":\"decimal_minvalue\",\"value\":-79228162514264337593543950335}],\"EntityState\":null,\"FormattedValues\":[],\"Id\":\"00000000-0000-0000-0000-000000000000\",\"KeyAttributes\":[],\"LogicalName\":null,\"RelatedEntities\":[],\"RowVersion\":null}", serializedEntity);
+
+            var deserializedEntity = EntitySerializer.Deserialize<Entity>(serializedEntity, entitySerializerOptions);
+            //No type information was preserved and defaults to decimal
+            Assert.Equal(123.345m, deserializedEntity.GetAttributeValue<decimal>("double"));
+            Assert.Equal(345.567m, deserializedEntity.GetAttributeValue<decimal>("decimal"));
+            Assert.Equal(Double.MaxValue, deserializedEntity.GetAttributeValue<double>("double_maxvalue"));
+            Assert.Equal(Double.MinValue, deserializedEntity.GetAttributeValue<double>("double_minvalue"));
+            Assert.Equal(Decimal.MaxValue, deserializedEntity.GetAttributeValue<decimal>("decimal_maxvalue"));
+            Assert.Equal(Decimal.MinValue, deserializedEntity.GetAttributeValue<decimal>("decimal_minvalue"));
+        }
     }
 }

--- a/PowerPlatform.EntitySerializer.Tests/PowerPlatform.EntitySerializer.Tests.csproj
+++ b/PowerPlatform.EntitySerializer.Tests/PowerPlatform.EntitySerializer.Tests.csproj
@@ -8,13 +8,13 @@
     <AssemblyOriginatorKeyFile>AlbanianXrm.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference  Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" Condition="'$(TargetFramework)'!='net462' AND '$(TargetFramework)'!='net472' AND '$(TargetFramework)'!='net48'">
+    </PackageReference>	
+    <PackageReference Include="coverlet.collector" Version="6.0.4" >
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/PowerPlatform.EntitySerializer/EntitySerializer.cs
+++ b/PowerPlatform.EntitySerializer/EntitySerializer.cs
@@ -122,7 +122,8 @@ namespace AlbanianXrm.PowerPlatform
                     CanConvert<RelatedEntityCollection>(item, entitySerializerOptions.converters) ||
                     CanConvert<Relationship>(item, entitySerializerOptions.converters) ||
                     CanConvert<RemoteExecutionContext>(item, entitySerializerOptions.converters) || 
-                    CanConvert<KeyValuePair<string, string>>(item, entitySerializerOptions.converters))
+                    CanConvert<KeyValuePair<string, string>>(item, entitySerializerOptions.converters) ||
+                    CanConvert<double>(item, entitySerializerOptions.converters))
                 {
                     continue;
                 }
@@ -267,6 +268,11 @@ namespace AlbanianXrm.PowerPlatform
             {
                 entitySerializerOptions.JsonSerializerOptions.Converters.Add(
                     entitySerializerOptions.converters.Set(new KeyValuePairStringStringConverter(entitySerializerOptions)));
+            }
+            if (!entitySerializerOptions.converters.CanConvertType<double>())
+            {
+                entitySerializerOptions.JsonSerializerOptions.Converters.Add(
+                    entitySerializerOptions.converters.Set(new DoubleConverter(entitySerializerOptions)));
             }
             if (!entitySerializerOptions.converters.CanConvertType<object>())
             {

--- a/PowerPlatform.EntitySerializer/JsonConverters/DoubleConverter.cs
+++ b/PowerPlatform.EntitySerializer/JsonConverters/DoubleConverter.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlbanianXrm.PowerPlatform.JsonConverters
+{
+    public class DoubleConverter : JsonConverter<double>, IObjectContractConverter
+    {
+        public const string TypeSchema = "Double:#System";
+
+        private readonly EntitySerializerOptions entitySerializerOptions;
+
+        public DoubleConverter(EntitySerializerOptions entitySerializerOptions)
+        {
+            this.entitySerializerOptions = entitySerializerOptions;
+        }
+
+        public string GetTypeSchema() { return TypeSchema; }
+
+        public object ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            reader.Read();
+                     
+            string propertyName = reader.GetString();
+            if (propertyName != EntitySerializer.ValuePropertyName)
+            {
+                throw new JsonException();
+            }
+            reader.Read();
+            var value = reader.GetDouble();
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.EndObject)
+            {
+                throw new JsonException();
+            }
+            return value;
+        }
+
+        public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                return reader.GetDouble();
+            }
+            else if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                reader.Read();
+                if (reader.GetString() != EntitySerializer.TypePropertyName)
+                {
+                    throw new JsonException();
+                }
+                reader.Read();
+                if (!TypeSchema.Equals(reader.GetString()))
+                {
+                    throw new JsonException();
+                }
+                return (double)ReadInternal(ref reader, typeToConvert, options);
+            }
+            else
+            {
+                throw new JsonException();
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+        {
+            var writingSchema = entitySerializerOptions.writingSchema;
+            if (entitySerializerOptions.WriteSchema == WriteSchemaOptions.IfNeeded)
+            {
+                writingSchema = true;
+            }
+            if (writingSchema)
+            {
+                writer.WriteStartObject();
+                writer.WriteString(EntitySerializer.TypePropertyName, TypeSchema);
+                writer.WriteNumber(EntitySerializer.ValuePropertyName, value);
+                writer.WriteEndObject();
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
+            entitySerializerOptions.writingSchema = writingSchema;
+        }
+    }
+}


### PR DESCRIPTION
When deserializing a number from json, it is decimal by default. However if it cannot be deserailized as decimal, it gets deserialized as double.

When serializing, Double preserves type info by default. It is important if lib used for serialization so that earlybound classes would work properly.